### PR TITLE
firewall: T4159: fix invalid nftables syntax for empty firewall groups

### DIFF
--- a/data/templates/firewall/nftables.tmpl
+++ b/data/templates/firewall/nftables.tmpl
@@ -9,37 +9,37 @@
 {% if group is defined %}
 {%   if group.address_group is defined %}
 {%     for group_name, group_conf in group.address_group.items() %}
-define A_{{ group_name }} = {
+define A_{{ group_name }} = { {% if group_conf.address|length > 0 %}
     {{ group_conf.address | join(",") }}
-}
+{% endif %} }
 {%     endfor %}
 {%   endif %}
 {%   if group.ipv6_address_group is defined %}
 {%     for group_name, group_conf in group.ipv6_address_group.items() %}
-define A6_{{ group_name }} = {
+define A6_{{ group_name }} = { {% if group_conf.address|length > 0 %}
     {{ group_conf.address | join(",") }}
-}
+{% endif %}}
 {%     endfor %}
 {%   endif %}
 {%   if group.network_group is defined %}
 {%     for group_name, group_conf in group.network_group.items() %}
-define N_{{ group_name }} = {
+define N_{{ group_name }} = { {% if group_conf.network|length > 0 %}
     {{ group_conf.network | join(",") }}
-}
+{% endif %} }
 {%     endfor %}
 {%   endif %}
 {%   if group.ipv6_network_group is defined %}
 {%     for group_name, group_conf in group.ipv6_network_group.items() %}
-define N6_{{ group_name }} = {
+define N6_{{ group_name }} = { {% if group_conf.network|length > 0 %}
     {{ group_conf.network | join(",") }}
-}
+{% endif %} }
 {%     endfor %}
 {%   endif %}
 {%   if group.port_group is defined %}
 {%     for group_name, group_conf in group.port_group.items() %}
-define P_{{ group_name }} = {
+define P_{{ group_name }} = { {% if group_conf.port|length > 0 %}
     {{ group_conf.port | join(",") }}
-}
+{% endif %} }
 {%     endfor %}
 {%   endif %}
 {% endif %}


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
Creates valid `nftables` code for empty firewall groups (which, in themselves, are valid), fix for issue reported in T4159

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4159

## Component(s) name
- `firewall`
## Proposed changes
Catch empty groups and create syntactically valid `nftables`code

## How to test
Commit empty firewall groups:
```
set firewall group address-group VYOS_NFT_TEST_ADDR description "Test to show empty address-group behaviour"
set firewall group network-group VYOS_NFT_TEST_NET description "Test to show empty network-group behaviour"
set firewall group port-group VYOS_NFT_TEST_PORT description "Test to show empty port-group behaviour"
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable **(Smoketests don't cover this edgecase yet)**
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

